### PR TITLE
Fix the associativity issue

### DIFF
--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -235,9 +235,9 @@ class OperatorNode(ExpTreeNode):
         if isinstance(val, int) or val == int(val): return int(val)
         return val
 
-    def __gt__(self, obj: "OperatorNode"):
+    def __ge__(self, obj: "OperatorNode"):
         assert isinstance(obj, OperatorNode)
-        return self.PreDefinedOperations.op_func_priority(self._inner_opt) > \
+        return self.PreDefinedOperations.op_func_priority(self._inner_opt) >= \
                 self.PreDefinedOperations.op_func_priority(obj._inner_opt)
         
     
@@ -284,7 +284,7 @@ class OperatorNode(ExpTreeNode):
                     stack.append(node)
                     node.children.append(hold_operand)
                 else:
-                    while stack[-1] > node: 
+                    while stack and stack[-1] >= node: 
                         prev_node = stack.pop()
                         prev_node.children.append(hold_operand)
                         hold_operand = prev_node


### PR DESCRIPTION
## Summary

Fix the associativity issue when evaluating mathematical expressions. 

### Examples

Prior to this fix, `5 - 3 - 2` will give `4` , _i.e., `5 - (3 - 2)`_ due the wrong associativity handling codes. Now this problem is fixed. See the screenshot below: 

<img width="212" alt="image" src="https://user-images.githubusercontent.com/43565614/205991862-571461f7-dccf-45e6-854a-be7db65d53a7.png">


## Logistics

close #6 